### PR TITLE
Fix ASP.NET SolrNet Client index Url

### DIFF
--- a/solr-client-configuration-overview.md
+++ b/solr-client-configuration-overview.md
@@ -67,7 +67,7 @@ conn = Solr('http://index.websolr.com/solr/0a1b2c3d4e5f')
 ### SolrNet
 
 ```csharp
-Startup.Init<Product>("http://localhost:8983/solr");
+Startup.Init<Product>("http://index.websolr.com/solr/0a1b2c3d4e5f");
 ```
 
 (Where `Product` is your [Solr document mapping class](http://code.google.com/p/solrnet/wiki/Mapping).)


### PR DESCRIPTION
Fix Url for ASP.NET - SolrNet client to use the same websolr index as the other clients.
