### PR TITLE
Updates the Sunspot links

### DIFF
--- a/Sunspot.md
+++ b/Sunspot.md
@@ -8,4 +8,7 @@
 
 ## Other links
 
-* **Home page:** * [http://outoftime.github.com/sunspot](http://outoftime.github.com/sunspot)
+* [Homepage](http://sunspot.github.io/)
+* [Github](https://github.com/sunspot/sunspot)
+* [Wiki](https://github.com/sunspot/sunspot/wiki)
+* [Bug Reports](https://github.com/sunspot/sunspot/issues)


### PR DESCRIPTION
The use of the old "outofime" link was bugging me, so I fixed it. I also added a few more link to the sunspot/sunspot project that other users should find handy.

Summary of changes:

- updated homepage to it's new home as a GH Pages site
- added (new) direct github link
- added github wiki link
- added github issues link