### PR TITLE
Update solr-clients.md

### DIFF
--- a/solr-clients.md
+++ b/solr-clients.md
@@ -71,3 +71,33 @@ If you know of a new client, please let us know or update this list.
 
 * [http://wiki.apache.org/solr/Solrj](http://wiki.apache.org/solr/Solrj)
 
+
+## Javascript
+
+### AJAX Solr
+
+* [https://github.com/evolvingweb/ajax-solr/wiki] (https://github.com/evolvingweb/ajax-solr/wiki)
+
+### Angular-Search
+
+* [https://github.com/newtonlabs/angular-search/] (https://github.com/newtonlabs/angular-search/)
+
+### EAC-CPF Ajax
+
+* [https://bitbucket.org/esrc/eaccpf-ajax] (https://bitbucket.org/esrc/eaccpf-ajax)
+
+### Solr Node Client
+
+* [http://lbdremy.github.io/solr-node-client/] (http://lbdremy.github.io/solr-node-client/)
+
+### Solrstrap
+
+* [http://fergiemcdowall.github.io/solrstrap/] (http://fergiemcdowall.github.io/solrstrap/)
+
+### Solstice
+
+* [https://github.com/front/solstice] (https://github.com/front/solstice)
+
+### Solr Search
+
+* [http://code.google.com/p/solr-search-html/] (http://code.google.com/p/solr-search-html/)


### PR DESCRIPTION
This is a suggestion to include Solr Javascript clients in "solr-clients.md".
The reason for this update is to include reference to (Solr Search), which was announced on Tue, 1-Apr-2014, to solr users' mailing list.
